### PR TITLE
Validate token access scopes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    octopus_auth (0.1.1)
+    octopus_auth (0.1.2)
       activerecord (>= 3.0.0)
 
 GEM

--- a/lib/octopus_auth.rb
+++ b/lib/octopus_auth.rb
@@ -10,6 +10,7 @@ require "octopus_auth/revoke"
 require "octopus_auth/queries"
 
 require "octopus_auth/authenticator"
+require "octopus_auth/access_scope_validator"
 
 module OctopusAuth
   class << self

--- a/lib/octopus_auth/access_scope_validator.rb
+++ b/lib/octopus_auth/access_scope_validator.rb
@@ -1,0 +1,24 @@
+module OctopusAuth
+  class AccessScopeValidator
+    def initialize(access_token)
+      @access_token = access_token
+      @access_scopes = (access_token.try(:access_scopes) || '').split(OctopusAuth.configuration.access_scopes_delimiter)
+    end
+
+    def valid?(*required_scopes)
+      access_all_scopes? || required_scopes.all? { |scope| access_scopes.include?(scope.to_s) }
+    end
+
+    def self.valid?(access_token, *required_scopes)
+      self.new(access_token).valid?(*required_scopes)
+    end
+
+    private
+
+    attr_reader :access_token, :access_scopes
+
+    def access_all_scopes?
+      access_scopes.any? { |scope| scope.to_s == OctopusAuth.configuration.access_scopes_wildcard.to_s }
+    end
+  end
+end

--- a/lib/octopus_auth/access_scope_validator.rb
+++ b/lib/octopus_auth/access_scope_validator.rb
@@ -18,7 +18,7 @@ module OctopusAuth
     attr_reader :access_token, :access_scopes
 
     def access_all_scopes?
-      access_scopes.any? { |scope| scope.to_s == OctopusAuth.configuration.access_scopes_wildcard.to_s }
+      access_scopes.any? { |scope| scope == OctopusAuth.configuration.access_scopes_wildcard.to_s }
     end
   end
 end

--- a/lib/octopus_auth/access_scope_validator.rb
+++ b/lib/octopus_auth/access_scope_validator.rb
@@ -2,7 +2,7 @@ module OctopusAuth
   class AccessScopeValidator
     def initialize(access_token)
       @access_token = access_token
-      @access_scopes = (access_token.try(:access_scopes) || '').split(OctopusAuth.configuration.access_scopes_delimiter)
+      @access_scopes = (access_token.access_scopes || '').split(OctopusAuth.configuration.access_scopes_delimiter)
     end
 
     def valid?(*required_scopes)

--- a/lib/octopus_auth/configuration.rb
+++ b/lib/octopus_auth/configuration.rb
@@ -6,5 +6,7 @@ module OctopusAuth
     attr_accessor :token_length
     attr_accessor :model_class
     attr_accessor :model_readonly
+    attr_accessor :access_scopes_delimiter
+    attr_accessor :access_scopes_wildcard
   end
 end

--- a/lib/octopus_auth/version.rb
+++ b/lib/octopus_auth/version.rb
@@ -1,3 +1,3 @@
 module OctopusAuth
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/octopus_auth/access_scope_validator_spec.rb
+++ b/spec/octopus_auth/access_scope_validator_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe OctopusAuth::AccessScopeValidator do
+  let(:required_scopes) { ['scope_1', 'scope_2'] }
+
+  subject { described_class.new(access_token) }
+
+  before do
+    OctopusAuth.configure do |config|
+      config.model_class = MockAccessToken
+      config.access_scopes_delimiter = ' '
+      config.access_scopes_wildcard = 'all'
+    end
+  end
+
+  context 'when token has no required scope' do
+    let(:access_token) do
+      MockAccessToken.new.tap do |token|
+        token.access_scopes = 'scope_3'
+      end
+    end
+
+    it 'returns false' do
+      expect(subject.valid?(*required_scopes)).to eq false
+    end
+  end
+
+  context 'when token has some required scopes' do
+    let(:access_token) do
+      MockAccessToken.new.tap do |token|
+        token.access_scopes = 'scope_3 scope_1'
+      end
+    end
+
+    it 'returns false' do
+      expect(subject.valid?(*required_scopes)).to eq false
+    end
+  end
+
+  context 'when token has all required scopes' do
+    let(:access_token) do
+      MockAccessToken.new.tap do |token|
+        token.access_scopes = 'scope_2 scope_1'
+      end
+    end
+
+    it 'returns true' do
+      expect(subject.valid?(*required_scopes)).to eq true
+    end
+  end
+
+  context 'when token has wildcard scope' do
+    let(:access_token) do
+      MockAccessToken.new.tap do |token|
+        token.access_scopes = 'all'
+      end
+    end
+
+    it 'returns true' do
+      expect(subject.valid?(*required_scopes)).to eq true
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ class MockAccessToken
   attr_accessor :owner_id
   attr_accessor :owner_type
   attr_accessor :creator_id
+  attr_accessor :access_scopes
 
   def active?
     !!active

--- a/tags
+++ b/tags
@@ -1,0 +1,66 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+AccessScopeValidator	lib/octopus_auth/access_scope_validator.rb	/^  class AccessScopeValidator$/;"	c	class:OctopusAuth
+Authenticator	lib/octopus_auth/authenticator.rb	/^  class Authenticator$/;"	c	class:OctopusAuth
+ByScope	lib/octopus_auth/queries/by_scope.rb	/^    class ByScope$/;"	c	class:OctopusAuth.Queries
+Configuration	lib/octopus_auth/configuration.rb	/^  class Configuration$/;"	c	class:OctopusAuth
+Decorators	lib/octopus_auth/decorators.rb	/^  module Decorators$/;"	m	class:OctopusAuth
+Decorators	lib/octopus_auth/decorators/default.rb	/^  module Decorators$/;"	m	class:OctopusAuth
+Default	lib/octopus_auth/decorators/default.rb	/^    class Default$/;"	c	class:OctopusAuth.Decorators
+Errors	lib/octopus_auth/errors.rb	/^  module Errors$/;"	m	class:OctopusAuth
+Errors	lib/octopus_auth/errors/token_not_found_error.rb	/^  module Errors$/;"	m	class:OctopusAuth
+Get	lib/octopus_auth/queries/get.rb	/^    class Get$/;"	c	class:OctopusAuth.Queries
+Issue	lib/octopus_auth/issue.rb	/^  class Issue$/;"	c	class:OctopusAuth
+MockAccessToken	spec/spec_helper.rb	/^class MockAccessToken$/;"	c
+OctopusAuth	lib/octopus_auth.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/access_scope_validator.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/authenticator.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/configuration.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/decorators.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/decorators/default.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/errors.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/errors/token_not_found_error.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/issue.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/queries.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/queries/by_scope.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/queries/get.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/revoke.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/token_generator.rb	/^module OctopusAuth$/;"	m
+OctopusAuth	lib/octopus_auth/version.rb	/^module OctopusAuth$/;"	m
+Queries	lib/octopus_auth/queries.rb	/^  module Queries$/;"	m	class:OctopusAuth
+Queries	lib/octopus_auth/queries/by_scope.rb	/^  module Queries$/;"	m	class:OctopusAuth
+Queries	lib/octopus_auth/queries/get.rb	/^  module Queries$/;"	m	class:OctopusAuth
+Revoke	lib/octopus_auth/revoke.rb	/^  class Revoke$/;"	c	class:OctopusAuth
+TokenGenerator	lib/octopus_auth/token_generator.rb	/^  class TokenGenerator$/;"	c	class:OctopusAuth
+TokenNotFoundError	lib/octopus_auth/errors/token_not_found_error.rb	/^    class TokenNotFoundError < StandardError$/;"	c	class:OctopusAuth.Errors
+access_all_scopes?	lib/octopus_auth/access_scope_validator.rb	/^    def access_all_scopes?$/;"	f	class:OctopusAuth.AccessScopeValidator
+active?	spec/spec_helper.rb	/^  def active?$/;"	f	class:MockAccessToken
+authenticate	lib/octopus_auth/authenticator.rb	/^    def authenticate$/;"	f	class:OctopusAuth.Authenticator
+build_success_result	lib/octopus_auth/authenticator.rb	/^    def build_success_result(access_token)$/;"	f	class:OctopusAuth.Authenticator
+configure	lib/octopus_auth.rb	/^  def self.configure$/;"	F
+execute	lib/octopus_auth/issue.rb	/^    def execute$/;"	f	class:OctopusAuth.Issue
+execute	lib/octopus_auth/queries/by_scope.rb	/^      def execute$/;"	f	class:OctopusAuth.Queries.ByScope
+execute	lib/octopus_auth/queries/get.rb	/^      def execute$/;"	f	class:OctopusAuth.Queries.Get
+execute	lib/octopus_auth/revoke.rb	/^    def execute$/;"	f	class:OctopusAuth.Revoke
+filtered_scope	lib/octopus_auth/issue.rb	/^    def filtered_scope$/;"	f	class:OctopusAuth.Issue
+filtered_scope	lib/octopus_auth/queries/by_scope.rb	/^      def filtered_scope$/;"	f	class:OctopusAuth.Queries.ByScope
+generate	lib/octopus_auth/token_generator.rb	/^      def generate(length)$/;"	f	class:OctopusAuth.TokenGenerator
+generate_token	lib/octopus_auth/issue.rb	/^    def generate_token$/;"	f	class:OctopusAuth.Issue
+initialize	lib/octopus_auth/access_scope_validator.rb	/^    def initialize(access_token)$/;"	f	class:OctopusAuth.AccessScopeValidator
+initialize	lib/octopus_auth/authenticator.rb	/^    def initialize(token, scope = nil)$/;"	f	class:OctopusAuth.Authenticator
+initialize	lib/octopus_auth/decorators/default.rb	/^      def initialize(token_model)$/;"	f	class:OctopusAuth.Decorators.Default
+initialize	lib/octopus_auth/issue.rb	/^    def initialize(scope, owner_type, owner_id, creator_id, expires_at: nil)$/;"	f	class:OctopusAuth.Issue
+initialize	lib/octopus_auth/queries/by_scope.rb	/^      def initialize(scope, owner_type, owner_id)$/;"	f	class:OctopusAuth.Queries.ByScope
+initialize	lib/octopus_auth/queries/get.rb	/^      def initialize(token)$/;"	f	class:OctopusAuth.Queries.Get
+initialize	lib/octopus_auth/revoke.rb	/^    def initialize(access_token_value)$/;"	f	class:OctopusAuth.Revoke
+relation	lib/octopus_auth/queries/by_scope.rb	/^      def relation$/;"	f	class:OctopusAuth.Queries.ByScope
+reset	lib/octopus_auth.rb	/^  def self.reset$/;"	F
+to_h	lib/octopus_auth/decorators/default.rb	/^      def to_h$/;"	f	class:OctopusAuth.Decorators.Default
+unique_token	lib/octopus_auth/token_generator.rb	/^      def unique_token$/;"	f	class:OctopusAuth.TokenGenerator
+valid	lib/octopus_auth/access_scope_validator.rb	/^    def self.valid?(access_token, *required_scopes)$/;"	F	class:OctopusAuth.AccessScopeValidator
+valid?	lib/octopus_auth/access_scope_validator.rb	/^    def valid?(*required_scopes)$/;"	f	class:OctopusAuth.AccessScopeValidator
+valid?	lib/octopus_auth/authenticator.rb	/^    def valid?(access_token)$/;"	f	class:OctopusAuth.Authenticator


### PR DESCRIPTION
Add access_scope_validator to validate token's access scopes

Usage
```
OctopusAuth::AccessScopeValidator.valid?('this_is_a_token', :resource_1, :resource_2)
```
