### PR TITLE
Tokens have one of required scopes are valid instead of all required scopes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    octopus_auth (0.1.2)
+    octopus_auth (0.1.3)
       activerecord (>= 3.0.0)
 
 GEM

--- a/lib/octopus_auth/access_scope_validator.rb
+++ b/lib/octopus_auth/access_scope_validator.rb
@@ -6,7 +6,7 @@ module OctopusAuth
     end
 
     def valid?(*required_scopes)
-      access_all_scopes? || required_scopes.all? { |scope| access_scopes.include?(scope.to_s) }
+      access_all_scopes? || required_scopes.any? { |scope| access_scopes.include?(scope.to_s) }
     end
 
     def self.valid?(access_token, *required_scopes)

--- a/lib/octopus_auth/version.rb
+++ b/lib/octopus_auth/version.rb
@@ -1,3 +1,3 @@
 module OctopusAuth
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/octopus_auth/access_scope_validator_spec.rb
+++ b/spec/octopus_auth/access_scope_validator_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe OctopusAuth::AccessScopeValidator do
       end
     end
 
-    it 'returns false' do
-      expect(subject.valid?(*required_scopes)).to eq false
+    it 'returns true' do
+      expect(subject.valid?(*required_scopes)).to eq true
     end
   end
 


### PR DESCRIPTION
Before: Tokens must have all required scopes to be valid.
Change: Tokens must have one of the required scopes to be valid.
Reason to change: To compatible with Doorkeeper