### PR TITLE
Config to force token expiration, issuers

### DIFF
--- a/lib/octopus_auth.rb
+++ b/lib/octopus_auth.rb
@@ -24,6 +24,6 @@ module OctopusAuth
   end
 
   def self.reset
-    self.configuration = OctopusAuth::Configuration.new
+    self.configuration = nil
   end
 end

--- a/lib/octopus_auth/configuration.rb
+++ b/lib/octopus_auth/configuration.rb
@@ -9,6 +9,6 @@ module OctopusAuth
     attr_accessor :access_scopes_delimiter
     attr_accessor :access_scopes_wildcard
 
-    attr_accessor :enfoce_jwt_expiration
+    attr_accessor :enforce_jwt_expiration
   end
 end

--- a/lib/octopus_auth/configuration.rb
+++ b/lib/octopus_auth/configuration.rb
@@ -8,5 +8,7 @@ module OctopusAuth
     attr_accessor :model_readonly
     attr_accessor :access_scopes_delimiter
     attr_accessor :access_scopes_wildcard
+
+    attr_accessor :enfoce_jwt_expiration
   end
 end

--- a/lib/octopus_auth/configuration.rb
+++ b/lib/octopus_auth/configuration.rb
@@ -9,6 +9,7 @@ module OctopusAuth
     attr_accessor :access_scopes_delimiter
     attr_accessor :access_scopes_wildcard
 
+    attr_accessor :hmac_secret
     attr_accessor :enforce_jwt_expiration
     attr_accessor :jwt_issuers
   end

--- a/lib/octopus_auth/configuration.rb
+++ b/lib/octopus_auth/configuration.rb
@@ -10,5 +10,6 @@ module OctopusAuth
     attr_accessor :access_scopes_wildcard
 
     attr_accessor :enforce_jwt_expiration
+    attr_accessor :jwt_issuers
   end
 end

--- a/lib/octopus_auth/hmac_authenticator.rb
+++ b/lib/octopus_auth/hmac_authenticator.rb
@@ -8,6 +8,14 @@ module OctopusAuth
         @hmac_secret = nil
       end
 
+      def fetch(token)
+        JWT.decode(token, hmac_secret, true, jwt_params)
+      rescue
+        nil
+      end
+
+      private
+
       def jwt_params
         @jwt_params ||= if Array(OctopusAuth.configuration.jwt_issuers).empty?
           { algorithm: "HS256" }
@@ -22,12 +30,6 @@ module OctopusAuth
 
       def hmac_secret
         @hmac_secret ||= OctopusAuth.configuration.hmac_secret
-      end
-
-      def fetch(token)
-        JWT.decode(token, hmac_secret, true, jwt_params)
-      rescue
-        nil
       end
     end
 

--- a/lib/octopus_auth/hmac_authenticator.rb
+++ b/lib/octopus_auth/hmac_authenticator.rb
@@ -10,7 +10,7 @@ module OctopusAuth
       payload = fetch_payload
       return false unless payload
 
-      if OctopusAuth.configuration.enfoce_jwt_expiration
+      if OctopusAuth.configuration.enforce_jwt_expiration
         && !payload.dig(1, :exp)
           return false
       end
@@ -28,9 +28,15 @@ module OctopusAuth
     end
 
     def fetch_payload
-      JWT.decode(token, hmac_secret, true, { algorithm: "HS256" })
+      JWT.decode(token, hmac_secret, true, jwt_params)
     rescue
       nil
+    end
+
+    def jwt_params
+      return { algorithm: "HS256" } if Array(OctopusAuth.configuration.jwt_issuers).empty?
+
+      { algorithm: "HS256", iss: OctopusAuth.configuration.jwt_issuers }
     end
 
     ResultObject = Struct.new(:token, :data)

--- a/lib/octopus_auth/hmac_authenticator.rb
+++ b/lib/octopus_auth/hmac_authenticator.rb
@@ -10,6 +10,11 @@ module OctopusAuth
       payload = fetch_payload
       return false unless payload
 
+      if OctopusAuth.configuration.enfoce_jwt_expiration
+        && !payload.dig(1, :exp)
+          return false
+      end
+
       yield(build_success_result(token, payload)) if block_given?
       true
     end

--- a/spec/octopus_auth/hmac_authenticator_spec.rb
+++ b/spec/octopus_auth/hmac_authenticator_spec.rb
@@ -10,47 +10,140 @@ RSpec.describe OctopusAuth::HmacAuthenticator do
       }
     end
 
-    before do
-      @prev_hmac_secret = ENV["HMAC_SECRET"]
-      ENV["HMAC_SECRET"] = "__TEST_HMAC_SECRET__"
-    end
-
-    after do
-      ENV["HMAC_SECRET"] = @prev_hmac_secret
-    end
-
-    context "JWT failed to verify" do
-      let(:token) { "__INVALID_TOKEN__" }
-
-      it { is_expected.to eq(false) }
-
-      it "does not yield payload" do
-        expect do |block|
-          described_class.new(token).authenticate(&block)
-        end.not_to yield_control
-      end
-    end
-
-    context "JWT verify succeed" do
-      # let(:token) { JWT.encode(payload, "__TEST_HMAC_SECRET__", "HS256") }
-      let(:token) do
-        "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoiX19TQU1QTEVfREFUQV9fIn0."\
-          "rFgKwv-fYJP7R0jRaluqmn-PH1p5-YiPZ83riAQ80dw"
-      end
-
-      it "returns true" do
-        expect(described_class.new(token).authenticate).to eq(true)
-      end
-
-      it "yields payload" do
-        expect do |block|
-          described_class.new(token).authenticate(&block)
-        end.to yield_control
-
-        described_class.new(token).authenticate do |result|
-          expect(result.token).to eq(token)
-          expect(result.data).to eq({"data" => "__SAMPLE_DATA__"})
+    describe "without iss or exp" do
+      before do
+        OctopusAuth.reset
+        described_class.reset
+        OctopusAuth.configure do |config|
+          config.hmac_secret = "__TEST_HMAC_SECRET__"
         end
+      end
+
+      context "JWT failed to verify" do
+        let(:token) { "__INVALID_TOKEN__" }
+
+        it { is_expected.to eq(false) }
+
+        it "does not yield payload" do
+          expect do |block|
+            described_class.new(token).authenticate(&block)
+          end.not_to yield_control
+        end
+      end
+
+      context "JWT verify succeed" do
+        # let(:token) { JWT.encode(payload, "__TEST_HMAC_SECRET__", "HS256") }
+        let(:token) do
+          "eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjoiX19TQU1QTEVfREFUQV9fIn0."\
+            "rFgKwv-fYJP7R0jRaluqmn-PH1p5-YiPZ83riAQ80dw"
+        end
+
+        it { is_expected.to eq(true) }
+
+        it "yields payload" do
+          expect do |block|
+            described_class.new(token).authenticate(&block)
+          end.to yield_control
+
+          described_class.new(token).authenticate do |result|
+            expect(result.token).to eq(token)
+            expect(result.data).to eq({"data" => "__SAMPLE_DATA__"})
+          end
+        end
+      end
+    end
+
+    describe "with iss" do
+      before do
+        OctopusAuth.reset
+        described_class.reset
+        OctopusAuth.configure do |config|
+          config.hmac_secret = "__TEST_HMAC_SECRET__"
+          config.jwt_issuers = ["Service A", "Service B"]
+        end
+      end
+
+      context "no iss" do
+        let(:token) { JWT.encode(payload, "__TEST_HMAC_SECRET__", "HS256") }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "valid iss" do
+        let(:token) do
+          JWT.encode(
+            payload.merge({ iss: "Service A" }),
+            "__TEST_HMAC_SECRET__",
+            "HS256"
+          )
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "invalid iss" do
+        let(:token) do
+          JWT.encode(
+            payload.merge({ iss: "Service C" }),
+            "__TEST_HMAC_SECRET__",
+            "HS256"
+          )
+        end
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe "with exp" do
+      before do
+        OctopusAuth.reset
+        described_class.reset
+        OctopusAuth.configure do |config|
+          config.hmac_secret = "__TEST_HMAC_SECRET__"
+          config.enforce_jwt_expiration = 3600
+        end
+      end
+
+      context "no exp" do
+        let(:token) { JWT.encode(payload, "__TEST_HMAC_SECRET__", "HS256") }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "valid exp" do
+        let(:token) do
+          JWT.encode(
+            payload.merge({ exp: Time.now.to_i + 1800 }),
+            "__TEST_HMAC_SECRET__",
+            "HS256"
+          )
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "expired exp" do
+        let(:token) do
+          JWT.encode(
+            payload.merge({ exp: Time.now.to_i - 18 }),
+            "__TEST_HMAC_SECRET__",
+            "HS256"
+          )
+        end
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "exp too long" do
+        let(:token) do
+          JWT.encode(
+            payload.merge({ exp: Time.now.to_i + 3601 }),
+            "__TEST_HMAC_SECRET__",
+            "HS256"
+          )
+        end
+
+        it { is_expected.to eq(false) }
       end
     end
   end


### PR DESCRIPTION
Changes: 

Enforce 2 JWT header params:

* [`exp`](https://github.com/jwt/ruby-jwt#expiration-time-claim) 
* Addition logic for exp, allow setup a `exp` limit, to avoid set `exp` too long. 
*  [`iss`](https://github.com/jwt/ruby-jwt#issuer-claim)

This means client must add these 2 params before signing token. And token must be resign timely as `exp` accepts only a limit duration. 
